### PR TITLE
Añade pruebas para la búsqueda de bookmarks en src/search.js

### DIFF
--- a/test/search.js
+++ b/test/search.js
@@ -11,6 +11,7 @@ const user = require('../src/user');
 const search = require('../src/search');
 const privileges = require('../src/privileges');
 const request = require('../src/request');
+const posts = require('../src/posts');
 
 describe('Search', () => {
 	let phoebeUid;
@@ -135,6 +136,48 @@ describe('Search', () => {
 		data = await socketCategories.categorySearch({ uid: phoebeUid }, { query: '', parentCid: 0 });
 		assert.strictEqual(data.length, 5);
 	});
+
+	it('should search in bookmarks', async () => {
+		posts.bookmark(post1Data.pid, gingerUid);
+		let result = await search.search({
+			searchIn: 'bookmarks',
+			uid: gingerUid,
+			categories: ['all'],
+		})
+		assert.strictEqual(result.matchCount, 1);
+		assert.strictEqual(result.posts[0].pid, post1Data.pid);
+	});
+
+	it('should not find any bookmark', async () => {
+		const result = await search.search({
+			searchIn: 'bookmarks',
+			uid: phoebeUid,
+			categories: ['all'],
+		});
+		assert.strictEqual(result.matchCount, 0);
+	});
+
+	it('should search bookmark by query', async () => {
+		posts.bookmark(post1Data.pid, gingerUid);
+		let result = await search.search({
+			query: 'nodebb',
+			searchIn: 'bookmarks',
+			uid: gingerUid,
+			categories: ['all'],
+			matchWords: "any",
+		});
+		assert.strictEqual(result.matchCount, 1);
+		assert.strictEqual(result.posts[0].pid, post1Data.pid);
+
+		result = await search.search({
+			query: 'xxxx',
+			searchIn: 'bookmarks',
+			uid: gingerUid,
+			categories: ['all'],
+			matchWords: "any",
+		});
+		assert.strictEqual(result.matchCount, 0);
+	})
 
 	it('should fail if searchIn is wrong', (done) => {
 		search.search({

--- a/test/search.js
+++ b/test/search.js
@@ -139,11 +139,11 @@ describe('Search', () => {
 
 	it('should search in bookmarks', async () => {
 		posts.bookmark(post1Data.pid, gingerUid);
-		let result = await search.search({
+		const result = await search.search({
 			searchIn: 'bookmarks',
 			uid: gingerUid,
 			categories: ['all'],
-		})
+		});
 		assert.strictEqual(result.matchCount, 1);
 		assert.strictEqual(result.posts[0].pid, post1Data.pid);
 	});
@@ -164,7 +164,7 @@ describe('Search', () => {
 			searchIn: 'bookmarks',
 			uid: gingerUid,
 			categories: ['all'],
-			matchWords: "any",
+			matchWords: 'any',
 		});
 		assert.strictEqual(result.matchCount, 1);
 		assert.strictEqual(result.posts[0].pid, post1Data.pid);
@@ -174,10 +174,10 @@ describe('Search', () => {
 			searchIn: 'bookmarks',
 			uid: gingerUid,
 			categories: ['all'],
-			matchWords: "any",
+			matchWords: 'any',
 		});
 		assert.strictEqual(result.matchCount, 0);
-	})
+	});
 
 	it('should fail if searchIn is wrong', (done) => {
 		search.search({


### PR DESCRIPTION
## Descripción
Este PR añade tres pruebas que revisan la búsqueda de _posts_ en _bookmarks_ de usuarios para cubrir código que no tenía pruebas asociadas.


## ¿Cómo se añadieron las pruebas?
Las pruebas le añaden a un usuario un _post_ a sus _bookmarks_. Luego, se realiza una búsqueda  de los _bookmarks_ del usuario y se revisa que se hayan encontrado correctamente. Por otro lado, también se revisa que, si la búsqueda no debe retornar nada si el usuario no tiene _bookmarks_ o si la cadena de caracteres a buscar no coincide con el _bookmark_ asociado al usuario, efectivamente no retorne algún _post_.

## Screenshots
Antes de los cambios:
![image](https://github.com/user-attachments/assets/3008f57e-2082-4024-8582-3a3ad5562d34)
![image](https://github.com/user-attachments/assets/02bf3390-aca1-4639-ad21-f89a23bb8c88)


Al añadir los cambios:
![image](https://github.com/user-attachments/assets/739e9849-b085-44fe-9c17-ce613803d4c4)
![image](https://github.com/user-attachments/assets/07373ae2-5b11-49a7-988d-df17a74f4301)

Cierra #30.