### PR TITLE
Convertir src/groups/search.js de JS a TS

### DIFF
--- a/src/groups/search.js
+++ b/src/groups/search.js
@@ -1,48 +1,36 @@
 "use strict";
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
-Object.defineProperty(exports, "__esModule", { value: true });
 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 const user_1 = __importDefault(require("../user"));
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 const database_1 = __importDefault(require("../database"));
-const groupsController = module.exports;
 function attachSearchFunctions(Groups) {
-    Groups.search = function (query, options = {}) {
-        return __awaiter(this, void 0, void 0, function* () {
-            if (!query) {
-                return [];
-            }
-            query = query.toLowerCase();
-            let groupNames = Object.values(yield database_1.default.getObject('groupslug:groupname'));
-            if (!options.hideEphemeralGroups) {
-                groupNames = Groups.ephemeralGroups.concat(groupNames);
-            }
-            groupNames = groupNames.filter((name) => name.toLowerCase().includes(query) && name !== Groups.BANNED_USERS // hide banned-users in searches
-            );
-            groupNames = groupNames.slice(0, 100);
-            let groupsData;
-            if (options.showMembers) {
-                groupsData = yield Groups.getGroupsAndMembers(groupNames);
-            }
-            else {
-                groupsData = yield Groups.getGroupsData(groupNames);
-            }
-            groupsData = groupsData.filter(Boolean);
-            if (options.filterHidden) {
-                groupsData = groupsData.filter(group => !group.hidden);
-            }
-            return Groups.sort(options.sort, groupsData) || []; // Ensure non-empty array return
-        });
+    Groups.search = async function (query, options = {}) {
+        if (!query) {
+            return [];
+        }
+        query = query.toLowerCase();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        let groupNames = Object.values(await database_1.default.getObject('groupslug:groupname'));
+        if (!options.hideEphemeralGroups) {
+            groupNames = Groups.ephemeralGroups.concat(groupNames);
+        }
+        groupNames = groupNames.filter((name) => name.toLowerCase().includes(query) && name !== Groups.BANNED_USERS);
+        groupNames = groupNames.slice(0, 100);
+        let groupsData;
+        if (options.showMembers) {
+            groupsData = await Groups.getGroupsAndMembers(groupNames);
+        }
+        else {
+            groupsData = await Groups.getGroupsData(groupNames);
+        }
+        groupsData = groupsData.filter(Boolean);
+        if (options.filterHidden) {
+            groupsData = groupsData.filter(group => !group.hidden);
+        }
+        return Groups.sort(options.sort, groupsData) || []; // Ensure non-empty array return
     };
     Groups.sort = function (strategy, groups) {
         switch (strategy) {
@@ -59,33 +47,33 @@ function attachSearchFunctions(Groups) {
         }
         return groups;
     };
-    Groups.searchMembers = function (data) {
-        return __awaiter(this, void 0, void 0, function* () {
-            if (!data.query) {
-                const users = yield Groups.getOwnersAndMembers(data.groupName, data.uid, 0, 19);
-                const matchCount = users.length;
-                const timing = '0.00';
-                return { users, matchCount, timing };
+    Groups.searchMembers = async function (data) {
+        if (!data.query) {
+            const users = await Groups.getOwnersAndMembers(data.groupName, data.uid, 0, 19);
+            const matchCount = users.length;
+            const timing = '0.00';
+            return { users, matchCount, timing };
+        }
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const results = await user_1.default.search(Object.assign(Object.assign({}, data), { paginate: false, hardCap: -1 }));
+        const uids = results.users.map(user => user === null || user === void 0 ? void 0 : user.uid);
+        const isOwners = await Groups.ownership.isOwners(uids, data.groupName);
+        results.users.forEach((user, index) => {
+            if (user) {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                user.isOwner = isOwners[index];
             }
-            const results = yield user_1.default.search(Object.assign(Object.assign({}, data), { paginate: false, hardCap: -1 }));
-            const uids = results.users.map(user => user === null || user === void 0 ? void 0 : user.uid);
-            const isOwners = yield Groups.ownership.isOwners(uids, data.groupName);
-            results.users.forEach((user, index) => {
-                if (user) {
-                    user.isOwner = isOwners[index];
-                }
-            });
-            results.users.sort((a, b) => {
-                if ((a === null || a === void 0 ? void 0 : a.isOwner) && !(b === null || b === void 0 ? void 0 : b.isOwner)) {
-                    return -1;
-                }
-                else if (!(a === null || a === void 0 ? void 0 : a.isOwner) && (b === null || b === void 0 ? void 0 : b.isOwner)) {
-                    return 1;
-                }
-                return 0;
-            });
-            return results;
         });
+        results.users.sort((a, b) => {
+            if ((a === null || a === void 0 ? void 0 : a.isOwner) && !(b === null || b === void 0 ? void 0 : b.isOwner)) {
+                return -1;
+            }
+            else if (!(a === null || a === void 0 ? void 0 : a.isOwner) && (b === null || b === void 0 ? void 0 : b.isOwner)) {
+                return 1;
+            }
+            return 0;
+        });
+        return results;
     };
 }
-exports.default = attachSearchFunctions;
+module.exports = attachSearchFunctions;

--- a/src/groups/search.js
+++ b/src/groups/search.js
@@ -1,86 +1,91 @@
-'use strict';
-
-const user = require('../user');
-const db = require('../database');
-
-module.exports = function (Groups) {
-	Groups.search = async function (query, options) {
-		if (!query) {
-			return [];
-		}
-		query = String(query).toLowerCase();
-		let groupNames = Object.values(await db.getObject('groupslug:groupname'));
-		if (!options.hideEphemeralGroups) {
-			groupNames = Groups.ephemeralGroups.concat(groupNames);
-		}
-		groupNames = groupNames.filter(
-			name => name.toLowerCase().includes(query) && name !== Groups.BANNED_USERS // hide banned-users in searches
-		);
-		groupNames = groupNames.slice(0, 100);
-
-		let groupsData;
-		if (options.showMembers) {
-			groupsData = await Groups.getGroupsAndMembers(groupNames);
-		} else {
-			groupsData = await Groups.getGroupsData(groupNames);
-		}
-		groupsData = groupsData.filter(Boolean);
-		if (options.filterHidden) {
-			groupsData = groupsData.filter(group => !group.hidden);
-		}
-		return Groups.sort(options.sort, groupsData);
-	};
-
-	Groups.sort = function (strategy, groups) {
-		switch (strategy) {
-			case 'count':
-				groups.sort((a, b) => a.slug > b.slug)
-					.sort((a, b) => b.memberCount - a.memberCount);
-				break;
-
-			case 'date':
-				groups.sort((a, b) => b.createtime - a.createtime);
-				break;
-
-			case 'alpha': // intentional fall-through
-			default:
-				groups.sort((a, b) => (a.slug > b.slug ? 1 : -1));
-		}
-
-		return groups;
-	};
-
-	Groups.searchMembers = async function (data) {
-		if (!data.query) {
-			const users = await Groups.getOwnersAndMembers(data.groupName, data.uid, 0, 19);
-			const matchCount = users.length;
-			const timing = '0.00';
-			return { users, matchCount, timing };
-		}
-
-		const results = await user.search({
-			...data,
-			paginate: false,
-			hardCap: -1,
-		});
-
-		const uids = results.users.map(user => user && user.uid);
-		const isOwners = await Groups.ownership.isOwners(uids, data.groupName);
-
-		results.users.forEach((user, index) => {
-			if (user) {
-				user.isOwner = isOwners[index];
-			}
-		});
-
-		results.users.sort((a, b) => {
-			if (a.isOwner && !b.isOwner) {
-				return -1;
-			} else if (!a.isOwner && b.isOwner) {
-				return 1;
-			}
-			return 0;
-		});
-		return results;
-	};
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
 };
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+const user_1 = __importDefault(require("../user"));
+const database_1 = __importDefault(require("../database"));
+const groupsController = module.exports;
+function attachSearchFunctions(Groups) {
+    Groups.search = function (query, options = {}) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!query) {
+                return [];
+            }
+            query = query.toLowerCase();
+            let groupNames = Object.values(yield database_1.default.getObject('groupslug:groupname'));
+            if (!options.hideEphemeralGroups) {
+                groupNames = Groups.ephemeralGroups.concat(groupNames);
+            }
+            groupNames = groupNames.filter((name) => name.toLowerCase().includes(query) && name !== Groups.BANNED_USERS // hide banned-users in searches
+            );
+            groupNames = groupNames.slice(0, 100);
+            let groupsData;
+            if (options.showMembers) {
+                groupsData = yield Groups.getGroupsAndMembers(groupNames);
+            }
+            else {
+                groupsData = yield Groups.getGroupsData(groupNames);
+            }
+            groupsData = groupsData.filter(Boolean);
+            if (options.filterHidden) {
+                groupsData = groupsData.filter(group => !group.hidden);
+            }
+            return Groups.sort(options.sort, groupsData) || []; // Ensure non-empty array return
+        });
+    };
+    Groups.sort = function (strategy, groups) {
+        switch (strategy) {
+            case 'count':
+                groups.sort((a, b) => a.slug.localeCompare(b.slug))
+                    .sort((a, b) => b.memberCount - a.memberCount);
+                break;
+            case 'date':
+                groups.sort((a, b) => b.createtime - a.createtime);
+                break;
+            case 'alpha': // intentional fall-through
+            default:
+                groups.sort((a, b) => (a.slug > b.slug ? 1 : -1));
+        }
+        return groups;
+    };
+    Groups.searchMembers = function (data) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!data.query) {
+                const users = yield Groups.getOwnersAndMembers(data.groupName, data.uid, 0, 19);
+                const matchCount = users.length;
+                const timing = '0.00';
+                return { users, matchCount, timing };
+            }
+            const results = yield user_1.default.search(Object.assign(Object.assign({}, data), { paginate: false, hardCap: -1 }));
+            const uids = results.users.map(user => user === null || user === void 0 ? void 0 : user.uid);
+            const isOwners = yield Groups.ownership.isOwners(uids, data.groupName);
+            results.users.forEach((user, index) => {
+                if (user) {
+                    user.isOwner = isOwners[index];
+                }
+            });
+            results.users.sort((a, b) => {
+                if ((a === null || a === void 0 ? void 0 : a.isOwner) && !(b === null || b === void 0 ? void 0 : b.isOwner)) {
+                    return -1;
+                }
+                else if (!(a === null || a === void 0 ? void 0 : a.isOwner) && (b === null || b === void 0 ? void 0 : b.isOwner)) {
+                    return 1;
+                }
+                return 0;
+            });
+            return results;
+        });
+    };
+}
+exports.default = attachSearchFunctions;

--- a/src/groups/search.ts
+++ b/src/groups/search.ts
@@ -1,0 +1,86 @@
+'use strict';
+
+const user = require('../user');
+const db = require('../database');
+
+module.exports = function (Groups) {
+	Groups.search = async function (query, options) {
+		if (!query) {
+			return [];
+		}
+		query = String(query).toLowerCase();
+		let groupNames = Object.values(await db.getObject('groupslug:groupname'));
+		if (!options.hideEphemeralGroups) {
+			groupNames = Groups.ephemeralGroups.concat(groupNames);
+		}
+		groupNames = groupNames.filter(
+			name => name.toLowerCase().includes(query) && name !== Groups.BANNED_USERS // hide banned-users in searches
+		);
+		groupNames = groupNames.slice(0, 100);
+
+		let groupsData;
+		if (options.showMembers) {
+			groupsData = await Groups.getGroupsAndMembers(groupNames);
+		} else {
+			groupsData = await Groups.getGroupsData(groupNames);
+		}
+		groupsData = groupsData.filter(Boolean);
+		if (options.filterHidden) {
+			groupsData = groupsData.filter(group => !group.hidden);
+		}
+		return Groups.sort(options.sort, groupsData);
+	};
+
+	Groups.sort = function (strategy, groups) {
+		switch (strategy) {
+			case 'count':
+				groups.sort((a, b) => a.slug > b.slug)
+					.sort((a, b) => b.memberCount - a.memberCount);
+				break;
+
+			case 'date':
+				groups.sort((a, b) => b.createtime - a.createtime);
+				break;
+
+			case 'alpha': // intentional fall-through
+			default:
+				groups.sort((a, b) => (a.slug > b.slug ? 1 : -1));
+		}
+
+		return groups;
+	};
+
+	Groups.searchMembers = async function (data) {
+		if (!data.query) {
+			const users = await Groups.getOwnersAndMembers(data.groupName, data.uid, 0, 19);
+			const matchCount = users.length;
+			const timing = '0.00';
+			return { users, matchCount, timing };
+		}
+
+		const results = await user.search({
+			...data,
+			paginate: false,
+			hardCap: -1,
+		});
+
+		const uids = results.users.map(user => user && user.uid);
+		const isOwners = await Groups.ownership.isOwners(uids, data.groupName);
+
+		results.users.forEach((user, index) => {
+			if (user) {
+				user.isOwner = isOwners[index];
+			}
+		});
+
+		results.users.sort((a, b) => {
+			if (a.isOwner && !b.isOwner) {
+				return -1;
+			} else if (!a.isOwner && b.isOwner) {
+				return 1;
+			}
+			return 0;
+		});
+		return results;
+	};
+};

--- a/src/groups/search.ts
+++ b/src/groups/search.ts
@@ -1,7 +1,7 @@
 'use strict';
 
-const user = require('../user');
-const db = require('../database');
+import user from '../user';
+import db from '../database';
 
 module.exports = function (Groups) {
 	Groups.search = async function (query, options) {

--- a/src/groups/search.ts
+++ b/src/groups/search.ts
@@ -1,40 +1,80 @@
-'use strict';
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 import user from '../user';
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 import db from '../database';
 
-module.exports = function (Groups) {
-	Groups.search = async function (query, options) {
+
+interface Groups {
+  slug: string;
+  memberCount: number;
+  hidden: boolean;
+  createtime: number;
+  search: (query: string, options: SearchOptions) => Promise<Groups[]>;
+  ephemeralGroups: string[];
+  BANNED_USERS: string;
+  getGroupsAndMembers: (groupNames: string[]) => Promise<Groups[]>;
+  getGroupsData: (groupNames: string[]) => Promise<Groups[]>;
+  sort: (strategy: string, groups: Groups[]) => Groups[];
+  searchMembers: (data: { query: string; groupName: string; uid?: number }) => Promise<SearchResults>;
+  getOwnersAndMembers: (groupName: string, uid?: number, start?: number, stop?: number) => Promise<User[]>;
+  ownership: {
+	isOwners: (uids: number[], groupName: string) => Promise<boolean[]>;
+  };
+}
+
+interface SearchOptions {
+  hideEphemeralGroups?: boolean;
+  showMembers?: boolean;
+  filterHidden?: boolean;
+  sort?: string;
+}
+
+interface SearchResults {
+  users: User[];
+  matchCount: number;
+  timing: string;
+}
+
+interface User {
+  uid: number;
+  isOwner?: boolean;
+}
+
+
+function attachSearchFunctions(Groups: Groups) {
+	Groups.search = async function (query: string, options: SearchOptions = {}): Promise<Groups[]> {
 		if (!query) {
 			return [];
 		}
-		query = String(query).toLowerCase();
-		let groupNames = Object.values(await db.getObject('groupslug:groupname'));
+		query = query.toLowerCase();
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+		let groupNames = Object.values(await db.getObject('groupslug:groupname') as Groups);
 		if (!options.hideEphemeralGroups) {
-			groupNames = Groups.ephemeralGroups.concat(groupNames);
+			groupNames = Groups.ephemeralGroups.concat(groupNames as string[]);
 		}
 		groupNames = groupNames.filter(
-			name => name.toLowerCase().includes(query) && name !== Groups.BANNED_USERS // hide banned-users in searches
+			(name: string) => name.toLowerCase().includes(query) && name !== Groups.BANNED_USERS
 		);
 		groupNames = groupNames.slice(0, 100);
 
-		let groupsData;
+		let groupsData: Groups[] | undefined;
 		if (options.showMembers) {
-			groupsData = await Groups.getGroupsAndMembers(groupNames);
+			groupsData = await Groups.getGroupsAndMembers(groupNames as string[]);
 		} else {
-			groupsData = await Groups.getGroupsData(groupNames);
+			groupsData = await Groups.getGroupsData(groupNames as string[]);
 		}
 		groupsData = groupsData.filter(Boolean);
 		if (options.filterHidden) {
 			groupsData = groupsData.filter(group => !group.hidden);
 		}
-		return Groups.sort(options.sort, groupsData);
+		return Groups.sort(options.sort, groupsData) || []; // Ensure non-empty array return
 	};
 
-	Groups.sort = function (strategy, groups) {
+	Groups.sort = function (strategy: string, groups: Groups[]): Groups[] {
 		switch (strategy) {
 			case 'count':
-				groups.sort((a, b) => a.slug > b.slug)
+				groups.sort((a, b) => a.slug.localeCompare(b.slug))
 					.sort((a, b) => b.memberCount - a.memberCount);
 				break;
 
@@ -49,38 +89,52 @@ module.exports = function (Groups) {
 
 		return groups;
 	};
-
-	Groups.searchMembers = async function (data) {
+	Groups.searchMembers = async function (data: {
+    query: string;
+    groupName: string;
+    uid?: number;
+  }): Promise<SearchResults> {
 		if (!data.query) {
-			const users = await Groups.getOwnersAndMembers(data.groupName, data.uid, 0, 19);
+			const users = await Groups.getOwnersAndMembers(
+				data.groupName,
+				data.uid,
+				0,
+				19
+			);
 			const matchCount = users.length;
 			const timing = '0.00';
 			return { users, matchCount, timing };
 		}
-
-		const results = await user.search({
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+		const results: SearchResults = await user.search({
 			...data,
 			paginate: false,
 			hardCap: -1,
-		});
+		}) as SearchResults;
 
-		const uids = results.users.map(user => user && user.uid);
-		const isOwners = await Groups.ownership.isOwners(uids, data.groupName);
+		const uids = results.users.map(user => user?.uid);
+		const isOwners = await Groups.ownership.isOwners(
+			uids,
+			data.groupName
+		);
 
 		results.users.forEach((user, index) => {
 			if (user) {
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 				user.isOwner = isOwners[index];
 			}
 		});
 
 		results.users.sort((a, b) => {
-			if (a.isOwner && !b.isOwner) {
+			if (a?.isOwner && !b?.isOwner) {
 				return -1;
-			} else if (!a.isOwner && b.isOwner) {
+			} else if (!a?.isOwner && b?.isOwner) {
 				return 1;
 			}
 			return 0;
 		});
 		return results;
 	};
-};
+}
+
+export = attachSearchFunctions

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "allowJs": false,
-    "target": "es6",
+    "target": "es2017",
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,


### PR DESCRIPTION
En este envío de cambios se resuelve el problema número #28 (corrige #28), que consiste en adaptar el archivo src/posts/data.js a TypeScript.

Para solucionar este problema, se bifurcó el repositorio NodeBB y se procedió a traducir el archivo src/groups/search.js a TypeScript. Luego, se creó un nuevo archivo data.ts en el mismo directorio, donde se reescribió el código original respetando la sintaxis de TypeScript. Finalmente, se generó el archivo JavaScript final (src/groups/search.js) a partir del archivo TypeScript utilizando npx tsc, reemplazando así la versión original.

Se realizaron pruebas locales con `npm run lint` y `npm run test` para verificar la calidad y el funcionamiento del código traducido a TypeScript. Además, se inició la aplicación localmente (`./nodeBB start`) para asegurar que no hubiera errores en tiempo de ejecución. Finalmente, se configuraron pruebas en GitHub Actions para automatizar estas comprobaciones en cada cambio.

Para soportar las funciones `async/await`, se actualizó el target en `tsconfig.json` de `es6` a `es2017`. Además, se utilizó el comentario `eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call` para suprimir temporalmente las advertencias del linter en las asignaciones de variables que involucran archivos aún no migrados a TypeScript.

